### PR TITLE
Change color coding of Yes / No code blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,8 +166,8 @@ ul > li {
 }
 
 /* Green is for go; Red is for stop! */
-.yes { border-bottom: 4px solid green; }
-.no { border-bottom: 4px solid red; }
+.yes + pre > code { background-color: #f3fff3; }
+.no + pre > code { background-color: #fff3f3; }
 
 /* Firefox is the worst. */
 @-moz-document url-prefix() {


### PR DESCRIPTION
It makes sense to apply `.yes` / `.no` classes to `<code>` blocks, but I wanted to keep content changes minimal, so I only changed the CSS.
