### PR TITLE
Reduce line spacing among the same heading

### DIFF
--- a/css/table_of_contents.css
+++ b/css/table_of_contents.css
@@ -31,7 +31,8 @@
 
 .toc-link.h1 {
   font-size: 1em;
-  line-height: 2em;
+  line-height: 1.2em;
+  margin: .8em 0;
 }
 
 .toc-link.h2 {


### PR DESCRIPTION
Fixes #11. Trades line-height for margin so spaces not between different lines of the same heading are similar. Current on left, PR on right

![screen shot 2017-03-21 at 6 06 48 pm](https://cloud.githubusercontent.com/assets/5297556/24174916/737b3a9c-0e61-11e7-9b16-9739c9c850cf.png)
