### PR TITLE
Fix missing scrollbar on macOS

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -319,6 +319,16 @@ pre > code {
   padding: 1rem 1.5rem;
   white-space: pre; }
 
+/* Ensure scrollbars are always visible on macOS */
+::-webkit-scrollbar {
+  -webkit-appearance: none;
+  width: 7px;
+  height: 5px; }
+::-webkit-scrollbar-thumb {
+  border-radius: 5px;
+  height: 2px;
+  background-color: rgba(0,0,0,.3);
+  -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5); }
 
 /* Tables
 –––––––––––––––––––––––––––––––––––––––––––––––––– */


### PR DESCRIPTION
This is a potential fix for https://github.com/kennethreitz/pep8.org/issues/2:

![screenshot 2017-05-24 22 52 37](https://cloud.githubusercontent.com/assets/306708/26437799/131585d6-40d4-11e7-8f9b-520b87f862ab.png)

It forces scrollbars to be visible on macOS. Simply setting `overflow-x: scroll` did not have the desired effect. Please also see: https://stackoverflow.com/questions/7492062/css-overflow-scroll-always-show-vertical-scroll-bar