### PR TITLE
Fix broken links to PEP 484

### DIFF
--- a/index.html
+++ b/index.html
@@ -1153,7 +1153,7 @@ No: if len(seq)
 <h2 id="function-annotations">Function Annotations</h2>
 
 
-<p>With the acceptance of <a href="pep 484">PEP 484</a>, the style rules for function annotations are changing.</p>
+<p>With the acceptance of <a href="https://www.python.org/dev/peps/pep-0484/">PEP 484</a>, the style rules for function annotations are changing.</p>
 
 <ul>
 
@@ -1161,7 +1161,7 @@ No: if len(seq)
 
 <li>The experimentation with annotation styles that was recommended previously in this PEP is no longer encouraged.</li>
 <p></p>
-<li>However, outside the stdlib, experiments within the rules of <a href="pep 484">PEP 484</a> are now encouraged. For example, marking up a large third party library or application with <a href="https://www.python.org/dev/peps/pep-0484/">PEP 484</a> style type annotations, reviewing how easy it was to add those annotations, and observing whether their presence increases code understandabilty.</li>
+<li>However, outside the stdlib, experiments within the rules of <a href="https://www.python.org/dev/peps/pep-0484/">PEP 484</a> are now encouraged. For example, marking up a large third party library or application with <a href="https://www.python.org/dev/peps/pep-0484/">PEP 484</a> style type annotations, reviewing how easy it was to add those annotations, and observing whether their presence increases code understandabilty.</li>
 <p></p>
 <li>The Python standard library should be conservative in adopting such annotations, but their use is allowed for new code and for big refactorings.</li>
 <p></p>


### PR DESCRIPTION
This fixes https://github.com/kennethreitz/pep8.org/issues/10.