### PR TITLE
Fix missing fonts on https://pep8.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <script src="js/table_of_contents.js"></script>
 
   <!-- FONT -->
-  <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7584432/7495152/css/fonts.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/425974/1F0A82D67708082E5.css" />
 
   <!-- CSS  -->
   <link rel="stylesheet" href="css/normalize.css">


### PR DESCRIPTION
Because we're loading our fonts CSS from cloud.typography.com there's a "weird" redirect from https://cloud.typography.com/7584432/7495152/css/fonts.css to http://pep8.org/fonts/425974/1F0A82D67708082E5.css (no HTTPS) which causes a mixed-content warning when accessing https://pep8.org/.

![screenshot 2017-05-25 16 58 38](https://cloud.githubusercontent.com/assets/306708/26475312/01b27b08-416c-11e7-87bf-f6070f09fd16.png)

This changeset loads the relevant font CSS locally from /fonts/425974/1F0A82D67708082E5.css. 

This should fix the mixed content warning and allow fonts to load on https://pep8.org/. However we might be in violation of some sort of licensing agreement for the font because presumably this cloud.typography.com redirect was done as a means to enforce licensing.