### PR TITLE
Add python3-version of the http server in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ If you serve this locally from `0.0.0.0`, the fonts will display properly. They 
 
 An easy way to do this:
 
-    $ python -m SimpleHTTPServer
+    $ python -m SimpleHTTPServer #python2
+or
+
+    $ python -m http.server      #python3
 
 ## Syncing PEP 8 changes
 


### PR DESCRIPTION
Not obvious to all that SimpleHTTPServer is python2-specific