### PR TITLE
Migrate to GitHub version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Whenever the original PEP 8 at python.org gets updated we need to migrate these 
 
 To migrate the latest changes from the original PEP 8 source do the following:
 
-* Look at the [source control history for the original PEP 8](https://hg.python.org/peps/log/tip/pep-0008.txt) and compare it with what's live on pep8.org. (As of 2017-05 we're tracking rev `c451868df657`.)
+* Look at the [source control history for the original PEP 8](https://github.com/python/peps/commits/master/pep-0008.txt) and compare it with what's live on pep8.org. (As of 2017-09 we're tracking rev `b61bb7d`.)
 
 * Apply the missing changes to `index.html` and create a pull-request to get them reviewed and live on pep8.org
 

--- a/content.sh
+++ b/content.sh
@@ -1,1 +1,1 @@
-curl -s https://hg.python.org/peps/raw-file/tip/pep-0008.txt | pandoc -S --toc --from rst --to html
+curl -s https://raw.githubusercontent.com/python/peps/master/pep-0008.txt | pandoc -S --toc --from rst --to html

--- a/index.html
+++ b/index.html
@@ -307,6 +307,8 @@ if (this_is_one_thing
         and that_is_another_thing):
     do_something()</code></pre>
 
+<p>(Also see the discussion of whether to break before or after binary operators below.)</p>
+
 <p>The closing brace/bracket/parenthesis on multi-line constructs may either line up under the first non-whitespace character of the last line of list, as in:</p>
 
 <pre><code class="language-python">my_list = [
@@ -823,7 +825,10 @@ Optional plotz says to frobnicate the bizbaz first.
 <li><code>UPPERCASE</code></li>
 <li><code>UPPER_CASE_WITH_UNDERSCORES</code></li>
 
-<li><code>CapitalizedWords</code> (or CapWords, CamelCase<a href="#fn5" class="footnoteRef" id="fnref5"><sup>5</sup></a>, StudlyCaps)</li>
+<li>
+<code>CapitalizedWords</code> (or CapWords, CamelCase<a href="#fn5" class="footnoteRef" id="fnref5"><sup>5</sup></a>, StudlyCaps)
+<p><strong>Note:</strong> When using abbreviations in CapWords, capitalize all the letters of the abbreviation. Thus HTTPServerError is better than HttpServerError.</p>
+</li>
 
 <li><code>mixedCase</code> (differs from CapitalizedWords by initial lowercase character!)</li>
 

--- a/index.html
+++ b/index.html
@@ -1179,7 +1179,7 @@ No: if len(seq):
 
 <li>The experimentation with annotation styles that was recommended previously in this PEP is no longer encouraged.</li>
 <p></p>
-<li>However, outside the stdlib, experiments within the rules of <a href="https://www.python.org/dev/peps/pep-0484/">PEP 484</a> are now encouraged. For example, marking up a large third party library or application with <a href="https://www.python.org/dev/peps/pep-0484/">PEP 484</a> style type annotations, reviewing how easy it was to add those annotations, and observing whether their presence increases code understandabilty.</li>
+<li>However, outside the stdlib, experiments within the rules of <a href="https://www.python.org/dev/peps/pep-0484/">PEP 484</a> are now encouraged. For example, marking up a large third party library or application with <a href="https://www.python.org/dev/peps/pep-0484/">PEP 484</a> style type annotations, reviewing how easy it was to add those annotations, and observing whether their presence increases code understandability.</li>
 <p></p>
 <li>The Python standard library should be conservative in adopting such annotations, but their use is allowed for new code and for big refactorings.</li>
 <p></p>

--- a/index.html
+++ b/index.html
@@ -849,13 +849,8 @@ Optional plotz says to frobnicate the bizbaz first.
 <p>Note that there is a separate convention for builtin names: most builtin names are single words (or two words run together), with the CapWords convention used only for exception names and builtin constants.</p>
 
 
-<h3 id="exception-names">Exception Names</h3>
-
-
-<p>Because exceptions should be classes, the class naming convention applies here. However, you should use the suffix “Error” on your exception names (if the exception actually is an error).</p>
-
-
 <h3 id="type-variable-names">Type variable names</h3>
+
 
 <p>Names of type variables introduced in PEP 484 should normally use CapWords
 preferring short names: <code>T</code>, <code>AnyStr</code>, <code>Num</code>. It is recommended to add
@@ -866,6 +861,12 @@ or contravariant behavior correspondingly. Examples</p>
 
   VT_co = TypeVar('VT_co', covariant=True)
   KT_contra = TypeVar('KT_contra', contravariant=True)</code></pre>
+
+
+<h3 id="exception-names">Exception Names</h3>
+
+
+<p>Because exceptions should be classes, the class naming convention applies here. However, you should use the suffix “Error” on your exception names (if the exception actually is an error).</p>
 
 
 <h3 id="global-variable-names">Global Variable Names</h3>

--- a/index.html
+++ b/index.html
@@ -875,7 +875,7 @@ Optional plotz says to frobnicate the bizbaz first.
 <h3 id="ascii-compatibility">ASCII Compatibility</h3>
 
 
-<p>Identifiers used in the standard library must be ASCII compatible as described in the <a href="https://www.python.org/dev/peps/pep-3131/#policy-specification">policy section</a> of PEP 3131.</p>
+<p>Identifiers used in the standard library must be ASCII compatible as described in the <a href="https://www.python.org/dev/peps/pep-3131/#policy-specification">policy section</a> of <a href="https://www.python.org/dev/peps/pep-3131">PEP 3131</a>.</p>
 
 
 <h3 id="package-and-module-names">Package and Module Names</h3>

--- a/index.html
+++ b/index.html
@@ -735,7 +735,7 @@ initialize(FILES,
 <pre><code class="language-python">FILES = ['setup.cfg', 'tox.ini',]
 initialize(FILES, error=True,)</code></pre>
 
-          
+
 <h1 id="comments">Comments</h1>
 
 
@@ -870,6 +870,12 @@ Optional plotz says to frobnicate the bizbaz first.
 <p>Never use the characters ‘l’ (lowercase letter el), ‘O’ (uppercase letter oh), or ‘I’ (uppercase letter eye) as single character variable names.</p>
 
 <p>In some fonts, these characters are indistinguishable from the numerals one and zero. When tempted to use ‘l’, use ‘L’ instead.</p>
+
+
+<h3 id="ascii-compatibility">ASCII Compatibility</h3>
+
+
+<p>Identifiers used in the standard library must be ASCII compatible as described in the <p><a href="https://www.python.org/dev/peps/pep-3131/#policy-specification">policy section</a> of PEP 3131.</p>
 
 
 <h3 id="package-and-module-names">Package and Module Names</h3>

--- a/index.html
+++ b/index.html
@@ -533,6 +533,16 @@ import sys
 
 </li>
 
+<li><p>Between a trailing comma and a following close parentheses. :</p>
+
+<p class="yes"><span>Yes:</span></p>
+<pre><code class="language-python">foo = (0,)</code></pre>
+
+<p class="no"><span>No:</span></p>
+<pre><code class="language-python">bar = (0, )</code></pre>
+
+</li>
+
 <li><p>Immediately before a comma, semicolon, or colon:</p>
 
 <p class="yes"><span>Yes:</span></p>
@@ -695,6 +705,37 @@ if foo == &#39;blah&#39;: one(); two(); three()</code></pre></li>
 </ul>
 
 
+<h1 id="when-to-use-trailing-commas">When to use trailing commas</h1>
+
+
+<p>Trailing commas are usually optional, except they are mandatory when making a tuple of one element (and in Python 2 they have semantics for the <code>print</code> statement).  For clarity, it is recommended to surround the latter in (technically redundant) parentheses.</p>
+
+<p class="yes"><span>Yes:</span></p>
+
+<pre><code class="language-python">FILES = ('setup.cfg',)</code></pre>
+
+<p>OK, but confusing:</p>
+
+<pre><code class="language-python">FILES = 'setup.cfg',</code></pre>
+
+<p>When trailing commas are redundant, they are often helpful when a version control system is used, when a list of values, arguments or imported items is expected to be extended over time. The pattern is to put each value (etc.) on a line by itself, always adding a trailing comma, and add the close parenthesis/bracket/brace on the next line. However it does not make sense to have a trailing comma on the same line as the closing delimiter (except in the above case of singleton tuples).</p>
+
+<p class="yes"><span>Yes:</span></p>
+
+<pre><code class="language-python">FILES = [
+    'setup.cfg',
+    'tox.ini',
+    ]
+initialize(FILES,
+           error=True,
+           )</code></pre>
+
+<p class="no"><span>No:</span></p>
+
+<pre><code class="language-python">FILES = ['setup.cfg', 'tox.ini',]
+initialize(FILES, error=True,)</code></pre>
+
+          
 <h1 id="comments">Comments</h1>
 
 

--- a/index.html
+++ b/index.html
@@ -875,7 +875,7 @@ Optional plotz says to frobnicate the bizbaz first.
 <h3 id="ascii-compatibility">ASCII Compatibility</h3>
 
 
-<p>Identifiers used in the standard library must be ASCII compatible as described in the <p><a href="https://www.python.org/dev/peps/pep-3131/#policy-specification">policy section</a> of PEP 3131.</p>
+<p>Identifiers used in the standard library must be ASCII compatible as described in the <a href="https://www.python.org/dev/peps/pep-3131/#policy-specification">policy section</a> of PEP 3131.</p>
 
 
 <h3 id="package-and-module-names">Package and Module Names</h3>
@@ -1177,14 +1177,21 @@ def bar(x):
 
 <p><code>startswith()</code> and <code>endswith()</code> are cleaner and less error prone. For example:</p>
 
-<pre><code class="language-python">Yes: if foo.startswith(&#39;bar&#39;):
-No:  if foo[:3] == &#39;bar&#39;:</code></pre></li>
+
+<p class="yes"><span>Yes:</span></p>
+<pre><code class="language-python">if foo.startswith(&#39;bar&#39;):</code></pre>
+
+<p class="no"><span>No:</span></p>
+<pre><code class="language-python">if foo[:3] == &#39;bar&#39;:</code></pre>
+</li>
 
 <li><p>Object type comparisons should always use <code>isinstance()</code> instead of comparing types directly. :</p>
 
-<pre><code class="language-python">Yes: if isinstance(obj, int):
+<p class="yes"><span>Yes:</span></p>
+<pre><code class="language-python">if isinstance(obj, int):</code></pre>
 
-No:  if type(obj) is type(1):</code></pre>
+<p class="no"><span>No:</span></p>
+<pre><code class="language-python">if type(obj) is type(1):</code></pre>
 
 <p>When checking if an object is a string, keep in mind that it might be a unicode string too! In Python 2, str and unicode have a common base class, basestring, so you can do:</p>
 
@@ -1194,11 +1201,14 @@ No:  if type(obj) is type(1):</code></pre>
 
 <li><p>For sequences, (strings, lists, tuples), use the fact that empty sequences are false. :</p>
 
-<pre><code class="language-python">Yes: if not seq:
-     if seq:
+<p class="yes"><span>Yes:</span></p>
+<pre><code class="language-python">if not seq:
+if seq:</code></pre>
 
-No: if len(seq):
-    if not len(seq):</code></pre></li>
+<p class="no"><span>No:</span></p>
+<pre><code class="language-python">if len(seq):
+if not len(seq):</code></pre>
+</li>
 
 <li>Don’t write string literals that rely on significant trailing whitespace. Such trailing whitespace is visually indistinguishable and some editors (or more recently, reindent.py) will trim them.</li>
 

--- a/index.html
+++ b/index.html
@@ -1193,7 +1193,7 @@ No: if len(seq):
 <p></p>
 <li>Users who don’t want to use type checkers are free to ignore them. However, it is expected that users of third party library packages may want to run type checkers over those packages. For this purpose <a href="https://www.python.org/dev/peps/pep-0484/">PEP 484</a> recommends the use of stub files: .pyi files that are read by the type checker in preference of the corresponding .py files. Stub files can be distributed with a library, or separately (with the library author’s permission) through the typeshed repo <a href="#fn6" class="footnoteRef" id="fnref6"><sup>6</sup></a>.</li>
 <p></p>
-<li><p>For code that needs to be backwards compatible, function annotations can be added in the form of comments. See the relevant section of PEP 484 <a href="#fn7" class="footnoteRef" id="fnref7"><sup>7</sup></a>.</p></li>
+<li><p>For code that needs to be backwards compatible, type annotations can be added in the form of comments. See the relevant section of PEP 484 <a href="#fn7" class="footnoteRef" id="fnref7"><sup>7</sup></a>.</p></li>
 
 </ul>
 

--- a/index.html
+++ b/index.html
@@ -533,7 +533,7 @@ import sys
 
 </li>
 
-<li><p>Between a trailing comma and a following close parentheses. :</p>
+<li><p>Between a trailing comma and a following close parenthesis. :</p>
 
 <p class="yes"><span>Yes:</span></p>
 <pre><code class="language-python">foo = (0,)</code></pre>


### PR DESCRIPTION
- I updated all the missing parts of PEP8 (mostly the part When to use trailing commas and ASCII Compatibility).
- I also checked for other missing parts( commit [add missing notes](https://github.com/kennethreitz/pep8.org/commit/eb5115cda8dd75abafea1964a0c93632357714aa)).
- Furthermore, I added yes/no css classes to the section Programming recommendations (commit [add yes/no classes](https://github.com/KPilnacek/pep8.org/commit/176ea960542a59a8385895c38333b9e1aa5a8633)).

Now, to the best of my knowledge, the pep8.org should be consistent with the official one :-).

Hope this helps.
Best regards
Krystof