### PR TITLE
netlify hosting

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [Settings]
-ID = "pep8org-mislav"
+ID = "pep8org"
 
 [build]
   base    = "/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,25 @@
+[Settings]
+ID = "pep8org-mislav"
+
+[build]
+  base    = "/"
+  publish = "/"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Feature-Policy = """
+        accelerometer 'none';
+        camera 'none';
+        geolocation 'none';
+        gyroscope 'none';
+        magnetometer 'none';
+        microphone 'none';
+        payment 'none';
+        usb 'none'
+        """
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Strict-Transport-Security = "max-age=2592000; preload" # one month for now
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "deny"
+    X-XSS-Protection = "1; mode=block"


### PR DESCRIPTION
This PR adds [Netlify](https://www.netlify.com/) as the hosting provider.

With Netlify pep8.org gets free SSL certs, preview deployments, easy way to set HTTP security headers...

Today, there is a [fair share of open source projects](https://www.netlify.com/open-source/) that use Netlify.

This PR still requires you @kennethreitz to set the project initially through Netlify web interface:
- login with Github on https://www.netlify.com/
- click "New site from Git"
- follow instructions on screen (you can allow Netlify to access only this repo or all of them)
- leave _master_ as the "Branch to deploy"
- leave "Build command" and "Publish directory" blank
- click deploy site
  - site is now being deployed to random netlify subdomain
- go to "Site settings" and click "Change site name" and set it to "pep8org"
  - site is now being deployed to _pep8org_ netlify subdomain

DNS record still needs to be changed.
Easiest way is to make a CNAME record with your DNS provider to pep8org.netlify.com

-----

This PR sets basic netlify config. I took the liberty to also set some security headers.
Feel free to change ID from `pep8org` to anything else what is available on the platform.

-----

I've also tested out the config myself (using `pep8-mislav` id).
- site deployed from master (without netlify config): https://pep8org-mislav.netlify.com/
- site deployed from branch (with netlify config): https://deploy-preview-1--pep8org-mislav.netlify.com/

-----

*Disclamer*:
I'm in no way affiliated with Netlify, I just like the product, especially _preview deployments_ :)