### PR TITLE
removed heroku instructions from readme and added netlify info

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ To migrate the latest changes from the original PEP 8 source do the following:
 
 * Apply the missing changes to `index.html` and create a pull-request to get them reviewed and live on pep8.org
 
-## Deploying
+## Deployment
 
-    $ heroku buildpacks:set https://github.com/hone/heroku-buildpack-static.git
+Automatically deployed on Netlify on each push to master.


### PR DESCRIPTION
After switch to Netlify in https://github.com/kennethreitz/pep8.org/pull/28., Heroku instructions are not necessary any more.