### PR TITLE
Keeping example/counter-example consistent in "Whitespace in Expressions and Statements"

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@ def munge() -&gt; AnyStr: ...</code></pre>
 <p class="no"><span>No:</span></p>
 
 <pre><code class="language-python">def munge(input:AnyStr): ...
-def munge()-&gt;PosInt: ...</code></pre></li>
+def munge()-&gt;AnyStr: ...</code></pre></li>
 
 <li><p>When combining an argument annotation with a default value, use spaces around the <code>=</code> sign (but only for those arguments that have both an annotation and a default).</p>
 
@@ -665,8 +665,8 @@ def munge(input: AnyStr, sep: AnyStr = None, limit=1000): ...</code></pre>
 
 <p class="no"><span>No:</span></p>
 
-<pre><code class="language-python">def munge(input: AnyStr=None): ...
-def munge(input: AnyStr, limit = 1000): ...</code></pre></li>
+<pre><code class="language-python">def munge(sep: AnyStr=None): ...
+def munge(input: AnyStr, sep: AnyStr=None, limit = 1000): ...</code></pre></li>
 
 <li><p>Compound statements (multiple statements on the same line) are generally discouraged.</p>
 


### PR DESCRIPTION
+ Edited examples in section, "Whitespace in Expressions and Statements,
    Other Recommendations"
+ `def munge(input: AnyStr=None):`
    to `def munge(sep: AnyStr=None):`
+ `def munge(input: AnyStr, limit = 1000):`
    to `def munge(input: AnyStr, sep: AnyStr=None, limit = 1000):`