### PR TITLE
*very* minor grammar error

### DIFF
--- a/index.html
+++ b/index.html
@@ -844,7 +844,7 @@ Optional plotz says to frobnicate the bizbaz first.
 
 <ul>
 
-<li><code>_single_leading_underscore</code>: weak “internal use” indicator. E.g. <code>from M import *</code> does not import objects whose name start with an underscore.</li>
+<li><code>_single_leading_underscore</code>: weak “internal use” indicator. E.g. <code>from M import *</code> does not import objects whose names start with an underscore.</li>
 <p></p>
 <li><p><code>single_trailing_underscore_</code>: used by convention to avoid conflicts with Python keyword, e.g.:</p>
 


### PR DESCRIPTION
see: https://github.com/python/peps/commit/2f8f1ec0ba92df5db85e9f78e7c2f422739ef1ec#diff-64ec08cc46db7540f18f2af46037f599

i know this is super nit-picky, but i couldn't help myself!

cheers :)

PS: It seems that the website has not kept up with master. One of the [last commits](https://github.com/dbader/pep8.org/commit/1f5bbdea877fc519536722280e9e74cdfff4ca6a#diff-eacf331f0ffc35d4b482f1d15a887d3b) to master did not seem to go through, if you compare the changes to index.html to what is displayed on pep8.org. But maybe I'm missing something! 