### PR TITLE
Reflect changes made in 2ce8884

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Whenever the original PEP 8 at python.org gets updated we need to migrate these 
 
 To migrate the latest changes from the original PEP 8 source do the following:
 
-* Look at the [source control history for the original PEP 8](https://github.com/python/peps/commits/master/pep-0008.txt) and compare it with what's live on pep8.org. (As of 2019-06 we're tracking rev `2f8f1ec`.)
+* Look at the [source control history for the original PEP 8](https://github.com/python/peps/commits/master/pep-0008.txt) and compare it with what's live on pep8.org. (As of 2019-09 we're tracking rev `2ce8884`.)
 
 * Apply the missing changes to `index.html` and create a pull-request to get them reviewed and live on pep8.org
 

--- a/index.html
+++ b/index.html
@@ -1220,6 +1220,15 @@ if not len(seq):</code></pre>
 <p class="no">Worse:</p>
 <pre><code class="language-python">if greeting is True:</code></pre></li>
 
+<li><p>Use of the flow control statements <code>return</code>/<code>break</code>/<code>continue</code> within the finally suite of a <code>try...finally</code>, where the flow control statement would jump outside the finally suite, is discouraged.  This is because such statements will implicitly cancel any active exception that is propagating through the finally suite.</p>
+<p class="no"><span>No:</span></p>
+<pre><code class="language-python">def foo():
+    try:
+        1 / 0
+    finally:
+        return 42
+</code></pre></li> 
+
 </ul>
 
 


### PR DESCRIPTION
I have migrated all the updates in pep8 up until the latest commit https://github.com/python/peps/commit/2ce88849fd9781399196a870265d7b63d047f313.
To my knowledge, the pep8.org is fully updated and in sync with the pep8 document.

Hope this helps.
Regards,
Bhumij Gupta